### PR TITLE
Switch to lineage apps for stock apps

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -12,6 +12,9 @@
            revision="refs/heads/11" />
   <remote  name="seedvault-app"
            fetch="https://github.com/seedvault-app/" />
+  <remote  name="lineageos"
+           fetch="https://github.com/GrapheneOS-Improvements/"
+           revision="refs/heads/lineage-18.1" />
   <default revision="refs/tags/android-11.0.0_r43"
            remote="aosp"
            sync-j="4" />
@@ -611,19 +614,19 @@
   <project path="packages/apps/CarrierConfig" name="platform/packages/apps/CarrierConfig" groups="pdk-cw-fs,pdk-fs" />
   <project path="packages/apps/CellBroadcastReceiver" name="platform/packages/apps/CellBroadcastReceiver" groups="pdk-cw-fs,pdk-fs" />
   <project path="packages/apps/CertInstaller" name="platform/packages/apps/CertInstaller" groups="pdk-cw-fs,pdk-fs" />
-  <project path="packages/apps/Contacts" name="platform_packages_apps_Contacts" groups="pdk-fs" remote="grapheneos" />
-  <project path="packages/apps/DeskClock" name="platform_packages_apps_DeskClock" groups="pdk-fs" remote="grapheneos" />
+  <project path="packages/apps/Contacts" name="platform_packages_apps_Contacts" groups="pdk-fs" remote="lineageos" />
+  <project path="packages/apps/DeskClock" name="platform_packages_apps_DeskClock" groups="pdk-fs" remote="lineageos" />
   <project path="packages/apps/DevCamera" name="platform/packages/apps/DevCamera" groups="pdk" />
-  <project path="packages/apps/Dialer" name="platform_packages_apps_Dialer" groups="pdk-fs" remote="grapheneos" />
+  <project path="packages/apps/Dialer" name="platform_packages_apps_Dialer" groups="pdk-fs" remote="lineageos" />
   <project path="packages/apps/DocumentsUI" name="platform/packages/apps/DocumentsUI" groups="pdk-cw-fs,pdk-fs" />
   <project path="packages/apps/EmergencyInfo" name="platform/packages/apps/EmergencyInfo" groups="pdk-fs" />
-  <project path="packages/apps/ExactCalculator" name="platform_packages_apps_ExactCalculator" remote="grapheneos" />
-  <project path="packages/apps/Gallery2" name="platform_packages_apps_Gallery2" groups="pdk-fs" remote="grapheneos" />
+  <project path="packages/apps/ExactCalculator" name="platform_packages_apps_ExactCalculator" remote="lineageos" />
+  <project path="packages/apps/Gallery2" name="platform_packages_apps_Gallery2" groups="pdk-fs" remote="lineageos" />
   <project path="packages/apps/HTMLViewer" name="platform/packages/apps/HTMLViewer" groups="pdk-fs" />
   <project path="packages/apps/KeyChain" name="platform/packages/apps/KeyChain" groups="pdk-fs" />
   <project path="packages/apps/Launcher3" name="platform_packages_apps_Launcher3" groups="pdk-fs" remote="grapheneos" />
   <project path="packages/apps/ManagedProvisioning" name="platform/packages/apps/ManagedProvisioning" groups="pdk-fs" />
-  <project path="packages/apps/Messaging" name="platform/packages/apps/Messaging" groups="pdk-fs" />
+  <project path="packages/apps/Messaging" name="platform_packages_apps_Messaging" groups="pdk-fs" remote="lineageos" />
   <project path="packages/apps/Music" name="platform/packages/apps/Music" groups="pdk-fs" />
   <project path="packages/apps/MusicFX" name="platform/packages/apps/MusicFX" groups="pdk-fs" />
   <project path="packages/apps/Nfc" name="platform_packages_apps_Nfc" groups="apps_nfc,pdk-fs" remote="grapheneos" />


### PR DESCRIPTION
# Switch to lineage apps for stock apps

## What is this pull request for

This pull request changes most of the stock user visible apps to the LineageOS variant instead of the AOSP variant.

- Contacts
- Dialer
- DeskClock
- ExactCalculator
- Gallery
- Messaging

## Why

Most stock AOSP applications seem to have been mostly abandoned and therefore fit in badly with modern android theming. For example none of these apps even have dark mode. But the biggest offender has got to be DeskClock which just looks absolutely horrendous.
After having diffed the stock LineageOS applications, it seems that most don't actually diverge that much from the AOSP applications. But the changes that have been made improve the apps greatly.
However Dialer, Contacts and Messaging seem to have made a lot more changes. But still, after having looked through the code, it looks like these changes are also fine and should not go against the morals of GrapheneOS.

## Extra changes

Most of the stock LineageOS applications can just be swapped in without any changes, but not all of them.
Dialer and Contacts both need to have some changes made to fit in properly, these changes are listed below.

### Contacts
Reapply commits from grapheneos:
- d515371: remove useless no-op privacy policy / terms of use
- 604d961: remove 'to Google' from Contacts backup notice

### DeskClock
No changes required

### Dialer
Reapply commits from grapheneos:
- 0d8292d: Add visual voicemail configs from Google Dialer …
Remove dependency on lineageSDK by removing the helplines module:
- 640d92f: Remove dependency on lineageSDK

### ExactCalculator
No changes required

### Gallery
No changes required

### Messaging
No changes required

## Manifest link

Right now I have added an extra link in the manifest to a new oranization containing forks of the LineageOS apps with the necessary changes made: https://github.com/GrapheneOS-Improvements/ .
But if you are going to merge this request I expect you to integrate these changes into the normal GrapheneOS  organization. And for the apps that don't require changes you could just directly reference the lineage repositories.