### PR TITLE
Update grapheneos-gitlab default branch to 13

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -9,7 +9,7 @@
            revision="refs/heads/13" />
   <remote  name="grapheneos-gitlab"
            fetch="https://gitlab.com/GrapheneOS/"
-           revision="refs/heads/12.1" />
+           revision="refs/heads/13" />
   <default revision="refs/tags/android-13.0.0_r3"
            remote="aosp"
            sync-j="4" />


### PR DESCRIPTION
This fetches the up-to-date and correct version of Vanadium prebuilts for Android 13.