### PR TITLE
Add kernel WireGuard support

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -10,6 +10,8 @@
   <remote  name="grapheneos-gitlab"
            fetch="https://gitlab.com/grapheneos/"
            revision="refs/heads/13" />
+  <remote  name="zx2c4"
+           fetch="https://git.zx2c4.com/" />
   <default revision="refs/tags/android-13.0.0_r35"
            remote="aosp"
            sync-j="4" />
@@ -898,6 +900,7 @@
   <project path="kernel/prebuilts/common-modules/virtual-device/mainline/arm64" name="kernel/prebuilts/common-modules/virtual-device/mainline/arm64" groups="pdk" clone-depth="1" />
   <project path="kernel/prebuilts/common-modules/virtual-device/mainline/x86-64" name="kernel/prebuilts/common-modules/virtual-device/mainline/x86-64" groups="pdk" clone-depth="1" />
   <project path="kernel/tests" name="kernel/tests" groups="vts,pdk" />
+  <project path="kernel/wireguard" name="android_kernel_wireguard" remote="zx2c4" revision="master" sync-s="true" />
   <project path="libcore" name="platform_libcore" groups="pdk" remote="grapheneos" />
   <project path="libnativehelper" name="platform/libnativehelper" groups="pdk" />
   <project path="packages/apps/BasicSmsReceiver" name="platform/packages/apps/BasicSmsReceiver" groups="pdk-cw-fs,pdk-fs" />


### PR DESCRIPTION
Adds support for [WireGuard in Android kernel](https://git.zx2c4.com/android_kernel_wireguard/about/). The WireGuard GUI app will automatically use this for better performance instead of the userspace Golang implementation.

It does increase attack surface slightly however WireGuard has been integrated into the base Linux kernel 5.6 and a similar implementation was done in OpenBSD.