### PR TITLE
android-security-14.0.0_r15

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -1257,7 +1257,7 @@
   <project path="system/incremental_delivery" name="platform/system/incremental_delivery" groups="pdk" />
   <project path="system/iorap" name="platform/system/iorap" groups="pdk" />
   <project path="system/keymaster" name="platform/system/keymaster" groups="pdk" />
-  <project path="system/keymint" name="platform/system/keymint" groups="pdk" />
+  <project path="system/keymint" name="platform_system_keymint" groups="pdk" remote="grapheneos" />
   <project path="system/libartpalette" name="platform/system/libartpalette" groups="pdk" />
   <project path="system/libbase" name="platform/system/libbase" groups="pdk" />
   <project path="system/libcppbor" name="platform/system/libcppbor" groups="pdk" />

--- a/default.xml
+++ b/default.xml
@@ -827,7 +827,7 @@
   <project path="external/sg3_utils" name="platform/external/sg3_utils" groups="pdk" />
   <project path="external/shaderc/spirv-headers" name="platform/external/shaderc/spirv-headers" groups="pdk" />
   <project path="external/shflags" name="platform/external/shflags" groups="pdk" />
-  <project path="external/skia" name="platform/external/skia" groups="pdk,qcom_msm8x26" />
+  <project path="external/skia" name="platform_external_skia" groups="pdk,qcom_msm8x26" remote="grapheneos" />
   <project path="external/sl4a" name="platform/external/sl4a" groups="pdk" />
   <project path="external/slf4j" name="platform/external/slf4j" groups="pdk" />
   <project path="external/snakeyaml" name="platform/external/snakeyaml" groups="pdk" />


### PR DESCRIPTION
Part of a changelist:
https://github.com/GrapheneOS-Archive/platform_external_skia/pull/11
https://github.com/GrapheneOS/platform_frameworks_base/pull/84
https://github.com/GrapheneOS/platform_frameworks_native/pull/24
https://github.com/GrapheneOS/platform_packages_apps_DocumentsUI/pull/20
https://github.com/GrapheneOS/platform_packages_apps_Settings/pull/313
https://github.com/GrapheneOS/platform_packages_modules_Bluetooth/pull/48
https://github.com/GrapheneOS/platform_packages_modules_Permission/pull/64
https://github.com/GrapheneOS/platform_packages_modules_Wifi/pull/36
https://github.com/GrapheneOS/platform_packages_providers_MediaProvider/pull/27
https://github.com/GrapheneOS/platform_packages_services_Telecomm/pull/13
https://github.com/GrapheneOS/platform_system_keymint/pull/1

https://github.com/GrapheneOS/adevtool/pull/175

https://github.com/GrapheneOS/script/pull/83