### PR TITLE
integrate population density repositories

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -76,6 +76,10 @@ additional_projects:
   - path: external/PdfViewer
     name: platform_external_PdfViewer
     clone_depth: 1
+  - path: external/population-density
+    name: platform_external_population-density
+    groups: pdk-fs
+    clone_depth: 1
   - path: external/SpeechServices
     name: platform_external_SpeechServices
     clone_depth: 1
@@ -160,6 +164,7 @@ forked_aosp_repos:
     - platform/frameworks/native
     - platform/frameworks/opt/net/wifi
     - platform/frameworks/opt/telephony
+    - platform/frameworks/proto_logging
     - platform/libcore
     - platform/packages/apps/Calendar
     - platform/packages/apps/CellBroadcastReceiver
@@ -209,6 +214,7 @@ forked_aosp_repos:
     - platform/system/vold
     - platform/system/zygote
     - platform/tools/apksig
+    - platform/tools/lint_checks
     - platform/tools/metalava
 clone_depth_1_aosp_repos:
   - platform/external/deqp

--- a/default.xml
+++ b/default.xml
@@ -470,6 +470,7 @@
   <project path="external/pixman" name="platform/external/pixman" groups="pdk"/>
   <project path="external/ply" name="platform/external/ply" groups="pdk"/>
   <project path="external/pogreb" name="platform/external/pogreb" groups="pdk"/>
+  <project path="external/population-density" name="platform_external_population-density" groups="pdk-fs" remote="grapheneos" clone-depth="1"/>
   <project path="external/private-join-and-compute" name="platform/external/private-join-and-compute" groups="pdk"/>
   <project path="external/protobuf" name="platform_external_protobuf" groups="pdk,sysui-studio" remote="grapheneos" aosp-name="platform/external/protobuf"/>
   <project path="external/pthreadpool" name="platform/external/pthreadpool" groups="pdk"/>
@@ -670,7 +671,7 @@
   <project path="frameworks/opt/timezonepicker" name="platform/frameworks/opt/timezonepicker" groups="pdk-cw-fs,pdk-fs"/>
   <project path="frameworks/opt/tv/tvsystem" name="platform/frameworks/opt/tv/tvsystem" groups="pdk-cw-fs,pdk-fs"/>
   <project path="frameworks/opt/vcard" name="platform/frameworks/opt/vcard" groups="pdk-cw-fs,pdk-fs"/>
-  <project path="frameworks/proto_logging" name="platform/frameworks/proto_logging" groups="pdk-cw-fs,pdk-fs,sysui-studio"/>
+  <project path="frameworks/proto_logging" name="platform_frameworks_proto_logging" groups="pdk-cw-fs,pdk-fs,sysui-studio" remote="grapheneos" aosp-name="platform/frameworks/proto_logging"/>
   <project path="frameworks/rs" name="platform/frameworks/rs" groups="pdk"/>
   <project path="frameworks/wilhelm" name="platform/frameworks/wilhelm" groups="pdk-cw-fs,pdk-fs"/>
   <project path="hardware/broadcom/libbt" name="platform/hardware/broadcom/libbt" groups="pdk"/>
@@ -1080,7 +1081,7 @@
   <project path="tools/doc_generation" name="platform/tools/doc_generation" groups="tools,pdk"/>
   <project path="tools/external_updater" name="platform/tools/external_updater" groups="tools"/>
   <project path="tools/external/fat32lib" name="platform/tools/external/fat32lib" groups="tools"/>
-  <project path="tools/lint_checks" name="platform/tools/lint_checks" groups="pdk"/>
+  <project path="tools/lint_checks" name="platform_tools_lint_checks" groups="pdk" remote="grapheneos" aosp-name="platform/tools/lint_checks"/>
   <project path="tools/loganalysis" name="platform/tools/loganalysis" groups="nopresubmit,pdk,tradefed"/>
   <project path="tools/mainline" name="platform/tools/mainline" groups="tools"/>
   <project path="tools/metalava" name="platform_tools_metalava" groups="pdk,tools" remote="grapheneos" aosp-name="platform/tools/metalava"/>


### PR DESCRIPTION
Add the manifest entries needed by the population density provider series:

- add `external/population-density` as the shallow `pdk-fs` GrapheneOS project `platform_external_population-density`
- switch `frameworks/proto_logging` and `tools/lint_checks` from AOSP checkouts to GrapheneOS forks
- update `config.yml` and `default.xml` together

The two AOSP forks retain their `aosp-name` metadata and are listed in `forked_aosp_repos`. The external project is listed in `additional_projects`.

A full `akita cur userdebug` build completed; the relevant framework, NetworkLocation, Rust, and location CTS tests passed; and density-based coarsening was verified on the development device.

Related repository: [GrapheneOS/platform_external_population-density](https://github.com/GrapheneOS/platform_external_population-density).

Related changes:

- GrapheneOS/script#114
- GrapheneOS/platform_packages_apps_NetworkLocation#38
- GrapheneOS/platform_frameworks_base#423
- GrapheneOS/platform_cts#4
